### PR TITLE
Refactored mkdir_p function to use os.makedirs

### DIFF
--- a/django_heroku/core.py
+++ b/django_heroku/core.py
@@ -15,20 +15,16 @@ def mkdir_p(newdir):
         - regular file in the way, raise an exception
         - parent directory(ies) does not exist, make them as well
     """
-    if os.path.isdir(newdir):
-        pass
-    elif os.path.isfile(newdir):
-        raise OSError(
-            "a file with the same name as the desired "
-            "dir, '%s', already exists." % newdir
-        )
-    else:
-        head, tail = os.path.split(newdir)
-        if head and not os.path.isdir(head):
-            mkdir_p(head)
-
-        if tail:
-            os.mkdir(newdir)
+    try:
+        os.makedirs(newdir)
+    except OSError as e:
+        if e.errno == errno.EEXIST and os.path.isdir(newdir):
+            pass
+        else:
+            raise OSError (
+                "a file with the same name as the desired "
+                "dir, '%s', already exists." % newdir
+            )
 
 
 class HerokuDiscoverRunner(DiscoverRunner):


### PR DESCRIPTION
There is already a method in the `os` that achieves the functionality that `mkdir -p` provides on `*nix` systems.

There are not tests yet. but i'm 99.9% sure that this works 😄 