### PR TITLE
Rename settings function to configure and update the test project

### DIFF
--- a/django_heroku/core.py
+++ b/django_heroku/core.py
@@ -42,7 +42,7 @@ class HerokuDiscoverRunner(DiscoverRunner):
         super(HerokuDiscoverRunner, self).teardown_databases(old_config, **kwargs)
 
 
-def settings(config, databases=True, multi_db=False, test_runner=True, staticfiles=True, allowed_hosts=True, logging=True, secret_key=True):
+def configure(config, databases=True, multi_db=False, test_runner=True, staticfiles=True, allowed_hosts=True, logging=True, secret_key=True):
 
     # Database configuration.
     # TODO: support other database (e.g. TEAL, AMBER, etc, automatically.)
@@ -144,4 +144,3 @@ def settings(config, databases=True, multi_db=False, test_runner=True, staticfil
     if secret_key:
         if 'SECRET_KEY' in os.environ:
             logger.info('Adding $SECRET_KEY to SECRET_KEY Django setting.')
-

--- a/test/testproject/settings.py
+++ b/test/testproject/settings.py
@@ -124,4 +124,4 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
-django_heroku.settings(locals())
+django_heroku.configure(locals())


### PR DESCRIPTION
Based on the timestamps in the blame of the ``README`` it looks like you want to call this function ``configure`` instead of ``settings``.

Have updated both the function and the test project.

Thanks for your great work!