### PR TITLE
Pull in CONN_MAX_AGE from config if provided

### DIFF
--- a/django_heroku/core.py
+++ b/django_heroku/core.py
@@ -51,6 +51,8 @@ def settings(config, *, db_colors=False, databases=True, test_runner=True, stati
         if 'DATABASES' not in config:
             config['DATABASES'] = {'default': None}
 
+        conn_max_age = config.get('CONN_MAX_AGE', MAX_CONN_AGE)
+            
         if db_colors:
             # Support all Heroku databases.
             # TODO: This appears to break TestRunner.
@@ -60,13 +62,13 @@ def settings(config, *, db_colors=False, databases=True, test_runner=True, stati
 
                     logger.info('Adding ${} to DATABASES Django setting ({}).'.format(env, db_color))
 
-                    config['DATABASES'][db_color] = dj_database_url.parse(url, conn_max_age=MAX_CONN_AGE, ssl_require=True)
+                    config['DATABASES'][db_color] = dj_database_url.parse(url, conn_max_age=conn_max_age, ssl_require=True)
 
         if 'DATABASE_URL' in os.environ:
             logger.info('Adding $DATABASE_URL to default DATABASE Django setting.')
 
             # Configure Django for DATABASE_URL environment variable.
-            config['DATABASES']['default'] = dj_database_url.config(conn_max_age=MAX_CONN_AGE, ssl_require=True)
+            config['DATABASES']['default'] = dj_database_url.config(conn_max_age=conn_max_age, ssl_require=True)
 
             logger.info('Adding $DATABASE_URL to TEST default DATABASE Django setting.')
 


### PR DESCRIPTION
If `settings.py` provide a [`CONN_MAX_AGE`](https://docs.djangoproject.com/en/2.0/ref/settings/#conn-max-age), we should use that value instead of setting it to `600` ms through `core.py`'s `MAX_CONN_AGE` setting.

By overriding this setting with `600`, this package causes some connection utilization issues on Heroku.