### PR TITLE
Updated psycopg2 to psycopg2-binary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ AUTHOR = 'Kenneth Reitz'
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    'dj-database-url>=0.5.0', 'whitenoise', 'psycopg2', 'django'
+    'dj-database-url>=0.5.0', 'whitenoise', 'psycopg2-binary', 'django'
 ]
 
 # The rest you shouldn't have to touch too much :)


### PR DESCRIPTION
This is to prevent this warning:

```UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.```