### PR TITLE
Don't require SSL to the database when running in debug mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,5 @@ ENV/
 .mypy_cache/
 
 /test/staticfiles/
+
+.pytest_cache

--- a/django_heroku/core.py
+++ b/django_heroku/core.py
@@ -56,7 +56,8 @@ def settings(config, *, db_colors=False, databases=True, test_runner=True, stati
             config['DATABASES'] = {'default': None}
 
         conn_max_age = config.get('CONN_MAX_AGE', MAX_CONN_AGE)
-            
+        ssl_require = not config.get('DEBUG', False)
+
         if db_colors:
             # Support all Heroku databases.
             # TODO: This appears to break TestRunner.
@@ -66,13 +67,13 @@ def settings(config, *, db_colors=False, databases=True, test_runner=True, stati
 
                     logger.info('Adding ${} to DATABASES Django setting ({}).'.format(env, db_color))
 
-                    config['DATABASES'][db_color] = dj_database_url.parse(url, conn_max_age=conn_max_age, ssl_require=True)
+                    config['DATABASES'][db_color] = dj_database_url.parse(url, conn_max_age=conn_max_age, ssl_require=ssl_require)
 
         if 'DATABASE_URL' in os.environ:
             logger.info('Adding $DATABASE_URL to default DATABASE Django setting.')
 
             # Configure Django for DATABASE_URL environment variable.
-            config['DATABASES']['default'] = dj_database_url.config(conn_max_age=conn_max_age, ssl_require=True)
+            config['DATABASES']['default'] = dj_database_url.config(conn_max_age=conn_max_age, ssl_require=ssl_require)
 
             logger.info('Adding $DATABASE_URL to TEST default DATABASE Django setting.')
 

--- a/django_heroku/core.py
+++ b/django_heroku/core.py
@@ -56,7 +56,7 @@ def settings(config, *, db_colors=False, databases=True, test_runner=True, stati
             config['DATABASES'] = {'default': None}
 
         conn_max_age = config.get('CONN_MAX_AGE', MAX_CONN_AGE)
-        ssl_require = not config.get('DEBUG', False)
+        ssl_require = not bool(os.environ.get('DATABASE_NO_SSL_REQUIRE'))
 
         if db_colors:
             # Support all Heroku databases.

--- a/test/test_django_heroku.py
+++ b/test/test_django_heroku.py
@@ -49,12 +49,11 @@ def test_secret_key():
 
 
 def test_database_ssl_require():
-    os.environ['DEBUG'] = ''
     imp.reload(config)
     assert config.DATABASES['default']['OPTIONS']['sslmode'] == 'require'
 
 
-def test_database_no_ssl_require_with_debug():
-    os.environ['DEBUG'] = 'Trueish'
+def test_database_no_ssl_require():
+    os.environ['DATABASE_NO_SSL_REQUIRE'] = 'Trueish'
     imp.reload(config)
     assert 'OPTIONS' not in config.DATABASES['default']

--- a/test/test_django_heroku.py
+++ b/test/test_django_heroku.py
@@ -46,3 +46,15 @@ def test_secret_key():
 
     imp.reload(config)
     assert config.SECRET_KEY == 'SECRET'
+
+
+def test_database_ssl_require():
+    os.environ['DEBUG'] = ''
+    imp.reload(config)
+    assert config.DATABASES['default']['OPTIONS']['sslmode'] == 'require'
+
+
+def test_database_no_ssl_require_with_debug():
+    os.environ['DEBUG'] = 'Trueish'
+    imp.reload(config)
+    assert 'OPTIONS' not in config.DATABASES['default']

--- a/test/testproject/settings.py
+++ b/test/testproject/settings.py
@@ -33,7 +33,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = 'o!su=g9edcn@uskpuy9e4mqw5f5tm9qz5n^6dx^c%ha71b285_'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = bool(os.environ.get('DEBUG', False))
 
 ALLOWED_HOSTS = []
 

--- a/test/testproject/settings.py
+++ b/test/testproject/settings.py
@@ -33,7 +33,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = 'o!su=g9edcn@uskpuy9e4mqw5f5tm9qz5n^6dx^c%ha71b285_'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = bool(os.environ.get('DEBUG', False))
+DEBUG = True
 
 ALLOWED_HOSTS = []
 


### PR DESCRIPTION
This is an attempt to fix #10.

If the environment variable `DATABASE_NO_SSL_REQUIRE` is truthy, then a database connection is not required.