### PR TITLE
change to binary distro of psycopg2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ AUTHOR = 'Kenneth Reitz'
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    'dj-database-url>=0.5.0', 'whitenoise', 'psycopg2', 'django'
+    'dj-database-url>=0.5.0', 'whitenoise', 'psycopg2-binary', 'django'
 ]
 
 # The rest you shouldn't have to touch too much :)


### PR DESCRIPTION
The latest `psycopg2` package always builds from source, which is counterproductive on Heroku. `psycopg2-binary` contains prebuilt drivers for supported architectures and should be used instead.